### PR TITLE
Fixes SemanticUI dropdown error when no results found

### DIFF
--- a/src/searchly/static/js/main.js
+++ b/src/searchly/static/js/main.js
@@ -103,7 +103,9 @@ $(document).ready(function() {
                 url: '/api/v1/song/search?query={query}'
             },
             minCharacters: 4,
-            placeholder: 'Song and/or Artist name'
+            placeholder: 'Song and/or Artist name',
+            filterRemoteData: true,
+            fullTextSearch: 'exact'
         });
 
     // Ajax


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/AlbertSuarez/searchly/blob/master/.github/CONTRIBUTING.md
-->

## What this PR does / Why we need it
This PR fixes #1. As @victorpm5 said on the issue, the SemanticUI dropdown didn't refresh when results aren't found after hitting the `/search` API endpoint.

## Which issue(s) this PR fixes (optional) 
<!--Fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged)-->
Fixes #1

## Special notes for your reviewer (optional)
None.

## Some questions
- [x] I have read the contributing guidelines
- [x] I abide by this repository Code of Conduct

<!--You can leave this and check them once the PR has been created.-->

## Additional Notes (optional)
Do you want to add anything else? We :heart: to hear your opinions!

This was fixed thanks to the following [issue](https://github.com/Semantic-Org/Semantic-UI/issues/6603) from SemanticUI repository.
